### PR TITLE
Correct Typo error

### DIFF
--- a/clink/app/src/loader/autorun.cpp
+++ b/clink/app/src/loader/autorun.cpp
@@ -439,7 +439,7 @@ static void print_help()
 
     puts("Autorun simplifies making modifications to cmd.exe's autorun registry\n"
         "variables. The value of these variables are read and executed by cmd.exe when\n"
-        "it starts. The 'install/uninstall' verbs add/remove the corrent command to run\n"
+        "it starts. The 'install/uninstall' verbs add/remove the current command to run\n"
         "Clink when cmd.exe starts. All '<args>' that follow 'install' are passed to\n"
         "Clink - see 'clink inject --help' for reference.\n");
 


### PR DESCRIPTION
There is a typo error displayed in the description when we run clink autorun --help command on Windows 11.